### PR TITLE
Support Faculty-prefixed environment variables

### DIFF
--- a/sherlockml/config.py
+++ b/sherlockml/config.py
@@ -73,18 +73,23 @@ def resolve_profile(
 
     resolved_credentials_path = (
         credentials_path
+        or os.getenv("FACULTY_CREDENTIALS_PATH")
         or os.getenv("SHERLOCKML_CREDENTIALS_PATH")
         or default_credentials_path()
     )
 
     resolved_profile_name = (
-        profile_name or os.getenv("SHERLOCKML_PROFILE") or DEFAULT_PROFILE
+        profile_name
+        or os.getenv("FACULTY_PROFILE")
+        or os.getenv("SHERLOCKML_PROFILE")
+        or DEFAULT_PROFILE
     )
 
     profile = load_profile(resolved_credentials_path, resolved_profile_name)
 
     resolved_domain = (
         domain
+        or os.getenv("FACULTY_DOMAIN")
         or os.getenv("SHERLOCKML_DOMAIN")
         or profile.domain
         or DEFAULT_DOMAIN
@@ -92,6 +97,7 @@ def resolve_profile(
 
     resolved_protocol = (
         protocol
+        or os.getenv("FACULTY_PROTOCOL")
         or os.getenv("SHERLOCKML_PROTOCOL")
         or profile.protocol
         or DEFAULT_PROTOCOL
@@ -99,6 +105,7 @@ def resolve_profile(
 
     resolved_client_id = (
         client_id
+        or os.getenv("FACULTY_CLIENT_ID")
         or os.getenv("SHERLOCKML_CLIENT_ID")
         or profile.client_id
         or _raise_credentials_error("client_id")
@@ -106,6 +113,7 @@ def resolve_profile(
 
     resolved_client_secret = (
         client_secret
+        or os.getenv("FACULTY_CLIENT_SECRET")
         or os.getenv("SHERLOCKML_CLIENT_SECRET")
         or profile.client_secret
         or _raise_credentials_error("client_secret")

--- a/sherlockml/datasets/__init__.py
+++ b/sherlockml/datasets/__init__.py
@@ -61,7 +61,7 @@ def ls(prefix="/", project_id=None, show_hidden=False, s3_client=None):
         is to list all files.
     project_id : str, optional
         The project to list files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     show_hidden : bool, optional
         Include hidden files in the output. Defaults to False.
@@ -158,7 +158,7 @@ def _isdir(project_path, project_id=None, s3_client=None):
         The path in the project datasets to test.
     project_id : str, optional
         The project to list files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     s3_client : botocore.client.S3, optional
         Advanced - a specific boto client for AWS S3 to use.
@@ -188,7 +188,7 @@ def _isfile(project_path, project_id=None, s3_client=None):
         The path in the project directory to test.
     project_id : str, optional
         The project to list files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     s3_client : botocore.client.S3, optional
         Advanced - a specific boto client for AWS S3 to use.
@@ -297,7 +297,7 @@ def put(local_path, project_path, project_id=None):
         The destination path in the project directory.
     project_id : str, optional
         The project to put files in. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     """
 
@@ -378,7 +378,7 @@ def get(project_path, local_path, project_id=None):
         The destination path in the local filesystem.
     project_id : str, optional
         The project to get files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     """
 
@@ -404,7 +404,7 @@ def mv(source_path, destination_path, project_id=None):
         The destination path in the project datasets.
     project_id : str, optional
         The project to get files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     """
 
@@ -425,7 +425,7 @@ def cp(source_path, destination_path, project_id=None, s3_client=None):
         The destination path in the project datasets.
     project_id : str, optional
         The project to get files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     s3_client : botocore.client.S3, optional
         Advanced - a specific boto client for AWS S3 to use.
@@ -466,7 +466,7 @@ def rm(project_path, project_id=None, s3_client=None):
         The path in the project datasets to remove.
     project_id : str, optional
         The project to get files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     s3_client : botocore.client.S3, optional
         Advanced - a specific boto client for AWS S3 to use.
@@ -493,7 +493,7 @@ def rmdir(project_path, project_id=None):
         The path of the directory to remove.
     project_id : str, optional
         The project to get files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
     """
 
@@ -527,7 +527,7 @@ def etag(project_path, project_id=None):
         The path in the project datasets.
     project_id : str, optional
         The project to get files from. You need to have access to this project
-        for it to work. Defaults to the project set by SHERLOCKML_PROJECT_ID in
+        for it to work. Defaults to the project set by FACULTY_PROJECT_ID in
         your environment.
 
     Returns

--- a/sherlockml/datasets/session.py
+++ b/sherlockml/datasets/session.py
@@ -24,15 +24,19 @@ class SherlockMLDatasetsError(Exception):
     pass
 
 
+def _raise_missing_project_id_error():
+    raise SherlockMLDatasetsError(
+        "No FACULTY_PROJECT_ID in environment - set the project ID "
+        "explicitly to use outside of SherlockML"
+    )
+
+
 def project_id_from_environment():
-    try:
-        project_id = os.environ["SHERLOCKML_PROJECT_ID"]
-    except KeyError:
-        raise SherlockMLDatasetsError(
-            "No SHERLOCKML_PROJECT_ID in environment - set the project ID "
-            "explicitly to use outside of SherlockML"
-        )
-    return project_id
+    return (
+        os.getenv("FACULTY_PROJECT_ID")
+        or os.getenv("SHERLOCKML_PROJECT_ID")
+        or _raise_missing_project_id_error()
+    )
 
 
 SECRETS_CACHE_TTL = 10

--- a/tests/datasets/fixtures.py
+++ b/tests/datasets/fixtures.py
@@ -87,7 +87,7 @@ TEST_NON_EXISTENT = "test_non_existent"
 
 @pytest.fixture
 def project_env(monkeypatch):
-    monkeypatch.setenv("SHERLOCKML_PROJECT_ID", str(uuid.uuid4()))
+    monkeypatch.setenv("FACULTY_PROJECT_ID", str(uuid.uuid4()))
 
 
 def _test_secrets():
@@ -109,7 +109,7 @@ def mock_secret_client(mocker):
 @pytest.fixture
 def project_directory(request, mock_secret_client, project_env):
 
-    project_id = os.environ["SHERLOCKML_PROJECT_ID"]
+    project_id = os.environ["FACULTY_PROJECT_ID"]
 
     # Make the empty directory
     _make_file(request, "")
@@ -159,7 +159,7 @@ def _s3_client():
 
 
 def _path_in_bucket(path):
-    project_id = os.environ["SHERLOCKML_PROJECT_ID"]
+    project_id = os.environ["FACULTY_PROJECT_ID"]
     combined = posixpath.join(project_id, path.lstrip("/"))
     if path.endswith("/"):
         return posixpath.normpath(combined) + "/"


### PR DESCRIPTION
This PR adds support for configuring with new `FACULTY_`-prefixed environment variables, and tests that these have precedence over the preexisting `SHERLOCKML_`-prefixed env vars.

Support for the new variables has not yet been added to the datasets module.