### PR TITLE
Revert default domain to sherlockml.com

### DIFF
--- a/faculty/config.py
+++ b/faculty/config.py
@@ -10,7 +10,7 @@ Profile = namedtuple(
 )
 
 DEFAULT_PROFILE = "default"
-DEFAULT_DOMAIN = "services.cloud.my.faculty.ai"
+DEFAULT_DOMAIN = "services.sherlockml.com"
 DEFAULT_PROTOCOL = "https"
 
 


### PR DESCRIPTION
We have not yet set up the new cloud.my.faculty.ai domain, so this
change will allow `faculty` to work with the default domain now.