### PR TITLE
Refactor auth module to have module-level cache

### DIFF
--- a/faculty/clients/auth.py
+++ b/faculty/clients/auth.py
@@ -24,7 +24,6 @@ AccessToken = namedtuple("AccessToken", ["token", "expires_at"])
 
 
 class _AccessTokenCache(object):
-
     def __init__(self):
         self._store = {}
 

--- a/faculty/clients/base.py
+++ b/faculty/clients/base.py
@@ -139,11 +139,7 @@ class BaseClient(object):
     def http_session(self):
         if self._http_session_cache is None:
             self._http_session_cache = requests.Session()
-            self._http_session_cache.auth = FacultyAuth(
-                _service_url(self.profile, "hudson"),
-                self.profile.client_id,
-                self.profile.client_secret,
-            )
+            self._http_session_cache.auth = FacultyAuth(self.profile)
         return self._http_session_cache
 
     def _request(self, method, endpoint, check_status=True, *args, **kwargs):

--- a/tests/clients/test_auth.py
+++ b/tests/clients/test_auth.py
@@ -17,14 +17,22 @@ from datetime import datetime, timedelta
 import pytest
 import pytz
 
-from faculty.clients.auth import AccessToken, AccessTokenClient, FacultyAuth
+from faculty.clients.auth import (
+    AccessToken,
+    _AccessTokenCache,
+    _get_access_token,
+    _get_access_token_cached,
+    FacultyAuth,
+)
+from tests.clients.fixtures import PROFILE
 
 
-MOCK_HUDSON_URL = "https://hudson.example.com"
-MOCK_CLIENT_ID = "client-id"
-MOCK_CLIENT_SECRET = "client-secret"
-MOCK_ACCESS_TOKEN_MATERIAL = "access-token"
+ACCESS_TOKEN_URL = "{}://hudson.{}/access_token".format(
+    PROFILE.protocol, PROFILE.domain
+)
+ACCESS_TOKEN_MATERIAL = "access-token"
 NOW = datetime.now(tz=pytz.utc)
+IN_TEN_MINUTES = NOW + timedelta(minutes=10)
 
 
 @pytest.fixture
@@ -34,66 +42,81 @@ def mock_datetime_now(mocker):
     return datetime_mock
 
 
-def test_access_token_client(requests_mock, mock_datetime_now):
+def test_access_token_cache(mock_datetime_now):
+    cache = _AccessTokenCache()
+    access_token = AccessToken(token="token", expires_at=IN_TEN_MINUTES)
+    cache.add(PROFILE, access_token)
+    assert cache.get(PROFILE) == access_token
+
+
+def test_access_token_cache_miss(mocker, mock_datetime_now):
+    cache = _AccessTokenCache()
+    access_token = AccessToken(token="token", expires_at=IN_TEN_MINUTES)
+    cache.add(PROFILE, access_token)
+    assert cache.get(mocker.Mock()) is None
+
+
+def test_access_token_cache_expired(mock_datetime_now):
+    cache = _AccessTokenCache()
+    access_token = AccessToken(
+        token="token", expires_at=NOW - timedelta(seconds=1)
+    )
+    cache.add(PROFILE, access_token)
+    assert cache.get(PROFILE) is None
+
+
+def test_get_access_token(requests_mock, mock_datetime_now):
 
     requests_mock.post(
-        "{}/access_token".format(MOCK_HUDSON_URL),
-        json={"access_token": MOCK_ACCESS_TOKEN_MATERIAL, "expires_in": 600},
+        ACCESS_TOKEN_URL,
+        json={"access_token": ACCESS_TOKEN_MATERIAL, "expires_in": 600},
     )
 
-    client = AccessTokenClient(MOCK_HUDSON_URL)
-    access_token = client.get_access_token(MOCK_CLIENT_ID, MOCK_CLIENT_SECRET)
+    access_token = _get_access_token(PROFILE)
 
     assert requests_mock.last_request.json() == {
-        "client_id": MOCK_CLIENT_ID,
-        "client_secret": MOCK_CLIENT_SECRET,
+        "client_id": PROFILE.client_id,
+        "client_secret": PROFILE.client_secret,
         "grant_type": "client_credentials",
     }
-    assert access_token.token == MOCK_ACCESS_TOKEN_MATERIAL
-    assert access_token.expires_at == NOW + timedelta(minutes=10)
+    assert access_token.token == ACCESS_TOKEN_MATERIAL
+    assert access_token.expires_at == IN_TEN_MINUTES
 
 
-@pytest.mark.parametrize(
-    "cached_token",
-    [None, AccessToken("old-token", NOW - timedelta(minutes=10))],
-)
-def test_faculty_auth(mocker, cached_token):
-
-    mock_client = mocker.Mock()
-    mock_client.get_access_token.return_value = AccessToken(
-        MOCK_ACCESS_TOKEN_MATERIAL, NOW + timedelta(minutes=10)
-    )
-    client_patch = mocker.patch(
-        "faculty.clients.auth.AccessTokenClient", return_value=mock_client
-    )
-
-    auth = FacultyAuth(MOCK_HUDSON_URL, MOCK_CLIENT_ID, MOCK_CLIENT_SECRET)
-
-    unauthenticated_request = mocker.Mock(headers={})
-    request = auth(unauthenticated_request)
-
-    assert request.headers["Authorization"] == "Bearer access-token"
-    client_patch.assert_called_once_with(MOCK_HUDSON_URL)
-    mock_client.get_access_token.assert_called_once_with(
-        MOCK_CLIENT_ID, MOCK_CLIENT_SECRET
-    )
-    assert auth.access_token is not None
+def test_get_access_token_cached(mocker):
+    """If cache has a token for the provided profile, return it."""
+    mock_cache = mocker.patch("faculty.clients.auth._ACCESS_TOKEN_CACHE")
+    assert _get_access_token_cached(PROFILE) == mock_cache.get.return_value
+    mock_cache.get.assert_called_once_with(PROFILE)
 
 
-def test_faculty_auth_cached(mocker):
+def test_get_access_token_cached_miss(mocker):
+    """If cache has no valid token for a profile, get a new one."""
 
-    mock_client = mocker.Mock()
+    mock_cache = mocker.patch("faculty.clients.auth._ACCESS_TOKEN_CACHE")
+    mock_cache.get.return_value = None
+
+    new_token = mocker.Mock()
     mocker.patch(
-        "faculty.clients.auth.AccessTokenClient", return_value=mock_client
+        "faculty.clients.auth._get_access_token", return_value=new_token
     )
 
-    auth = FacultyAuth(MOCK_HUDSON_URL, MOCK_CLIENT_ID, MOCK_CLIENT_SECRET)
-    auth.access_token = AccessToken(
-        MOCK_ACCESS_TOKEN_MATERIAL, NOW + timedelta(minutes=10)
+    assert _get_access_token_cached(PROFILE) == new_token
+    mock_cache.add.assert_called_once_with(PROFILE, new_token)
+
+
+def test_faculty_auth(mocker):
+
+    access_token = AccessToken(token="access-token", expires_at=IN_TEN_MINUTES)
+    get_access_token_cached_mock = mocker.patch(
+        "faculty.clients.auth._get_access_token_cached",
+        return_value=access_token,
     )
+
+    auth = FacultyAuth(PROFILE)
 
     unauthenticated_request = mocker.Mock(headers={})
     request = auth(unauthenticated_request)
 
     assert request.headers["Authorization"] == "Bearer access-token"
-    mock_client.get_access_token.assert_not_called()
+    get_access_token_cached_mock.assert_called_once_with(PROFILE)

--- a/tests/clients/test_base.py
+++ b/tests/clients/test_base.py
@@ -38,8 +38,6 @@ from tests.clients.fixtures import PROFILE
 AUTHORIZATION_HEADER_VALUE = "Bearer mock-token"
 AUTHORIZATION_HEADER = {"Authorization": AUTHORIZATION_HEADER_VALUE}
 
-HUDSON_URL = "https://hudson.test.domain.com"
-
 BAD_RESPONSE_STATUSES = [
     (400, BadRequest),
     (401, Unauthorized),
@@ -69,9 +67,7 @@ def patch_auth(mocker):
 
     yield
 
-    mock_auth.assert_called_once_with(
-        HUDSON_URL, PROFILE.client_id, PROFILE.client_secret
-    )
+    mock_auth.assert_called_once_with(PROFILE)
 
 
 DummyObject = namedtuple("DummyObject", ["foo"])


### PR DESCRIPTION
A future PR will aim to add disk-based caching of auth tokens too.