### PR TITLE
Use tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .pytest_cache/
 __pycache__/
 *.pyc
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,11 @@ dist: xenial
 
 matrix:
   include:
-    - name: Check black formatting
-      python: 3.7
+    - python: 3.7
       env: TOXENV=black
-    - name: Check flake8 on Python 3
-      python: 3.7
+    - python: 3.7
       env: TOXENV=flake8
-    - name: Check flake8 on Python 2
-      python: 2.7
+    - python: 2.7
       env: TOXENV=flake8
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,36 @@
 language: python
 cache: pip
-install:
-  - pip install flake8
-jobs:
+
+matrix:
   include:
     - name: Check black formatting
-      stage: test
-      install:
-        - pip install black
-      script:
-        - black --check .
       python: "3.6"
-    - stage: test
-      script:
-        - flake8
-        - python setup.py test
-      python: "2.7"
-    - stage: test
-      script:
-        - flake8
-        - python setup.py test
-      python: "3.4"
-    - stage: test
-      script:
-        - flake8
-        - python setup.py test
-      python: "3.5"
-    - stage: test
-      script:
-        - flake8
-        - python setup.py test
-      python: "3.6"
-    - stage: test
-      script:
-        - flake8
-        - python setup.py test
-      dist: xenial
+      env: TOXENV=black
+    - name: Check flake8 on Python 3
       python: "3.7"
+      env: TOXENV=flake8
+    - name: Check flake8 on Python 2
+      python: "2.7"
+      env: TOXENV=flake8
+    - stage: test
+      python: "2.7"
+      env: TOXENV=py27
+    - stage: test
+      python: "3.4"
+      env: TOXENV=py34
+    - stage: test
+      python: "3.5"
+      env: TOXENV=py35
+    - stage: test
+      python: "3.6"
+      env: TOXENV=py36
+    - stage: test
+      dist: xenial
+      py36-python: "3.7"
+      env: TOXENV=py37
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,33 @@
 language: python
 cache: pip
+dist: xenial
 
 matrix:
   include:
     - name: Check black formatting
-      python: "3.6"
+      python: 3.7
       env: TOXENV=black
     - name: Check flake8 on Python 3
-      python: "3.6"
+      python: 3.7
       env: TOXENV=flake8
     - name: Check flake8 on Python 2
-      python: "2.7"
+      python: 2.7
       env: TOXENV=flake8
+
     - stage: test
-      python: "2.7"
+      python: 2.7
       env: TOXENV=py27
     - stage: test
-      python: "3.4"
+      python: 3.4
       env: TOXENV=py34
     - stage: test
-      python: "3.5"
+      python: 3.5
       env: TOXENV=py35
     - stage: test
-      python: "3.6"
+      python: 3.6
       env: TOXENV=py36
     - stage: test
-      dist: xenial
-      py36-python: "3.7"
+      python: 3.7
       env: TOXENV=py37
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       python: "3.6"
       env: TOXENV=black
     - name: Check flake8 on Python 3
-      python: "3.7"
+      python: "3.6"
       env: TOXENV=flake8
     - name: Check flake8 on Python 2
       python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ matrix:
     - name: Check black formatting
       python: 3.7
       env: TOXENV=black
-    - name: Check flake8 on Python 3
-      python: 3.7
-      env: TOXENV=flake8
     - name: Check flake8 on Python 2
       python: 2.7
       env: TOXENV=flake8
-
+    - name: Check flake8 on Python 3
+      python: 3.7
+      env: TOXENV=flake8
     - stage: test
       python: 2.7
       env: TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,15 @@ matrix:
     - name: Check flake8 on Python 3
       python: 3.7
       env: TOXENV=flake8
-    - stage: test
-      python: 2.7
+    - python: 2.7
       env: TOXENV=py27
-    - stage: test
-      python: 3.4
+    - python: 3.4
       env: TOXENV=py34
-    - stage: test
-      python: 3.5
+    - python: 3.5
       env: TOXENV=py35
-    - stage: test
-      python: 3.6
+    - python: 3.6
       env: TOXENV=py36
-    - stage: test
-      python: 3.7
+    - python: 3.7
       env: TOXENV=py37
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ dist: xenial
 
 matrix:
   include:
-    - python: 3.7
+    - name: Check black formatting
+      python: 3.7
       env: TOXENV=black
-    - python: 3.7
+    - name: Check flake8 on Python 3
+      python: 3.7
       env: TOXENV=flake8
-    - python: 2.7
+    - name: Check flake8 on Python 2
+      python: 2.7
       env: TOXENV=flake8
 
     - stage: test

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,7 @@ setup(
     license="Apache Software License",
     packages=find_packages(),
     use_scm_version={"version_scheme": "post-release"},
-    setup_requires=["setuptools_scm", "pytest-runner"],
-    tests_require=[
-        "pytest",
-        "pytest-mock",
-        "requests_mock",
-        "python-dateutil>=2.7",
-    ],
+    setup_requires=["setuptools_scm"],
     install_requires=[
         "requests",
         "pytz",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ toxworkdir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]
 sitepackages = False
+passenv = AWS_*
 commands = python setup.py test {posargs}
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = py27, py34, py35, py36, py37, flake8, black
+toxworkdir = {env:TOX_WORK_DIR:.tox}
+
+[testenv]
+sitepackages = False
+commands = python setup.py test {posargs}
+
+[testenv:flake8]
+skip_install = True
+deps =
+    flake8
+commands =
+    flake8
+
+[testenv:black]
+skip_install = True
+basepython = python3.7
+deps =
+    black==18.9b0
+commands =
+    black {posargs:--check setup.py faculty tests}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py27, py34, py35, py36, py37, flake8, black
-toxworkdir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]
 sitepackages = False

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
 
 [testenv:black]
 skip_install = True
-basepython = python3.7
 deps =
     black==18.9b0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,12 @@ toxworkdir = {env:TOX_WORK_DIR:.tox}
 [testenv]
 sitepackages = False
 passenv = AWS_*
-commands = python setup.py test {posargs}
+deps =
+    pytest
+    pytest-mock
+    requests_mock
+    python-dateutil>=2.7
+commands = pytest {posargs}
 
 [testenv:flake8]
 skip_install = True


### PR DESCRIPTION
This adds a minimal tox setup to make it easy to run CI like tests locally. It also reduces the places where the test command is specified to a single one in `tox.ini` as opposed to one for every job in `.travis.yml`.

The last line also means we could get rid of `pytest-runner` in favour of running plain `py.test` within tox. Since tox uses pip instead of setuptools to resolve dependencies, it would result in the installed packages being closer to what a user will see in an installed version of `faculty`.